### PR TITLE
3.0.10

### DIFF
--- a/.yamato/CI.yml
+++ b/.yamato/CI.yml
@@ -1,8 +1,6 @@
 codeeditor: rider
 
 editors:
-  - version: 2019.2
-  - version: 2019.3
   - version: 2019.4
   - version: 2020.1
   - version: 2020.2

--- a/.yamato/CI.yml
+++ b/.yamato/CI.yml
@@ -1,6 +1,8 @@
 codeeditor: rider
 
 editors:
+  - version: 2019.2
+  - version: 2019.3
   - version: 2019.4
   - version: 2020.1
   - version: 2020.2

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -32,7 +32,7 @@ namespace Packages.Rider.Editor.Tests
         }
 
         [Test]
-        public void PerojectNameForDefines1()
+        public void ProjectNameForDefines1()
         {
             Assert.AreEqual("name", m_AssemblyNameProvider.GetProjectName("name", new []{"UNITY_EDITOR"}));
         }

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -52,7 +52,7 @@ namespace Packages.Rider.Editor.Tests
 
             foreach (var assembly in collectedAssemblies)
             {
-                Assert.That(assembly.outputPath, Is.EqualTo(@"Temp\Bin\Debug\"), $"{assembly.name}: had wrong output path: {assembly.outputPath}");
+                Assert.That(assembly.outputPath, Is.EqualTo($@"Temp\Bin\Debug\{assembly.name}\"), $"{assembly.name}: had wrong output path: {assembly.outputPath}");
             }
             foreach (Assembly editorAssembly in editorAssemblies)
             {
@@ -111,7 +111,7 @@ namespace Packages.Rider.Editor.Tests
 
             foreach (Assembly playerAssembly in playerAssemblies)
             {
-                Assert.IsTrue(collectedAssemblies.Any(assembly => assembly.name == playerAssembly.name && assembly.outputPath == @"Temp\Bin\Debug\Player\"), $"{playerAssembly.name}: was not found in collection.");
+                Assert.IsTrue(collectedAssemblies.Any(assembly => assembly.name == playerAssembly.name && assembly.outputPath == $@"Temp\Bin\Debug\{playerAssembly.name}\Player\"), $"{playerAssembly.name}: was not found in collection.");
             }
         }
     }

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -38,7 +38,7 @@ namespace Packages.Rider.Editor.Tests
         }
         
         [Test]
-        public void PerojectNameForDefines2()
+        public void ProjectNameForDefines2()
         {
             Assert.AreEqual("name.Player", m_AssemblyNameProvider.GetProjectName("name", new []{""}));
         }

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -31,15 +31,15 @@ namespace Packages.Rider.Editor.Tests
             m_AssemblyNameProvider.ResetProjectGenerationFlag();
         }
 
-        [TestCase(@"Temp\Bin\Debug\", "AssemblyName", "AssemblyName")]
-        [TestCase(@"Temp\Bin\Debug\", "My.Player.AssemblyName", "My.Player.AssemblyName")]
-        [TestCase(@"Temp\Bin\Debug\", "AssemblyName.Player", "AssemblyName.Player")]
-        [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName", "AssemblyName.Player")]
-        [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName.Player", "AssemblyName.Player.Player")]
-        public void GetOutputPath_ReturnsPlayerAndeditorOutputPath(string assemblyOutputPath, string assemblyName, string expectedAssemblyName)
-        {
-            Assert.AreEqual(expectedAssemblyName, m_AssemblyNameProvider.GetProjectName(assemblyOutputPath, assemblyName));
-        }
+        // [TestCase(@"Temp\Bin\Debug\", "AssemblyName", "AssemblyName")]
+        // [TestCase(@"Temp\Bin\Debug\", "My.Player.AssemblyName", "My.Player.AssemblyName")]
+        // [TestCase(@"Temp\Bin\Debug\", "AssemblyName.Player", "AssemblyName.Player")]
+        // [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName", "AssemblyName.Player")]
+        // [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName.Player", "AssemblyName.Player.Player")]
+        // public void GetOutputPath_ReturnsPlayerAndeditorOutputPath(string assemblyOutputPath, string assemblyName, string expectedAssemblyName)
+        // {
+        //     Assert.AreEqual(expectedAssemblyName, m_AssemblyNameProvider.GetProjectName(assemblyOutputPath, assemblyName));
+        // }
 
         [Test]
         public void AllEditorAssemblies_AreCollected()

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -35,12 +36,6 @@ namespace Packages.Rider.Editor.Tests
         public void ProjectNameForDefines1()
         {
             Assert.AreEqual("name", m_AssemblyNameProvider.GetProjectName("name", new []{"UNITY_EDITOR"}));
-        }
-        
-        [Test]
-        public void ProjectNameForDefines2()
-        {
-            Assert.AreEqual("name.Player", m_AssemblyNameProvider.GetProjectName("name", new []{""}));
         }
 
         [Test]

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -31,15 +31,17 @@ namespace Packages.Rider.Editor.Tests
             m_AssemblyNameProvider.ResetProjectGenerationFlag();
         }
 
-        // [TestCase(@"Temp\Bin\Debug\", "AssemblyName", "AssemblyName")]
-        // [TestCase(@"Temp\Bin\Debug\", "My.Player.AssemblyName", "My.Player.AssemblyName")]
-        // [TestCase(@"Temp\Bin\Debug\", "AssemblyName.Player", "AssemblyName.Player")]
-        // [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName", "AssemblyName.Player")]
-        // [TestCase(@"Temp\Bin\Debug\Player\", "AssemblyName.Player", "AssemblyName.Player.Player")]
-        // public void GetOutputPath_ReturnsPlayerAndeditorOutputPath(string assemblyOutputPath, string assemblyName, string expectedAssemblyName)
-        // {
-        //     Assert.AreEqual(expectedAssemblyName, m_AssemblyNameProvider.GetProjectName(assemblyOutputPath, assemblyName));
-        // }
+        [Test]
+        public void PerojectNameForDefines1()
+        {
+            Assert.AreEqual("name", m_AssemblyNameProvider.GetProjectName("name", new []{"UNITY_EDITOR"}));
+        }
+        
+        [Test]
+        public void PerojectNameForDefines2()
+        {
+            Assert.AreEqual("name.Player", m_AssemblyNameProvider.GetProjectName("name", new []{""}));
+        }
 
         [Test]
         public void AllEditorAssemblies_AreCollected()

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
@@ -27,13 +27,13 @@ namespace Packages.Rider.Editor.Tests
             }
 
             [Test]
-            public void ProjectGeneration_UseAssemblyNameProvider_ForOutputPath()
+            public void ProjectGeneration_UseAssemblyNameProvider_ForDefines()
             {
                 var expectedAssemblyName = "my.AssemblyName";
-                var synchronizer = m_Builder.WithOutputPathForAssemblyPath(m_Builder.Assembly.outputPath, m_Builder.Assembly.name, expectedAssemblyName).Build();
-
+                var synchronizer = m_Builder.WithNameForDefines(m_Builder.Assembly.defines, m_Builder.Assembly.name, expectedAssemblyName).Build();
+            
                 synchronizer.Sync();
-
+            
                 var filePath = MakeAbsolutePathTestImplementation($"{expectedAssemblyName}.csproj").NormalizePath();
                 Assert.That(m_Builder.FileExists(filePath), $"{filePath} doesn't exist");
             }
@@ -68,7 +68,7 @@ namespace Packages.Rider.Editor.Tests
                     "    <OutputType>Library</OutputType>",
                     "    <AppDesignerFolder>Properties</AppDesignerFolder>",
                     $"    <AssemblyName>{m_Builder.Assembly.name}</AssemblyName>",
-                    "    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>",
+                    $"    <TargetFramework>{m_Builder.Assembly.compilerOptions.ApiCompatibilityLevel}</TargetFramework>",
                     "    <FileAlignment>512</FileAlignment>",
                     "    <BaseDirectory>.</BaseDirectory>",
                     "  </PropertyGroup>",
@@ -216,7 +216,7 @@ namespace Packages.Rider.Editor.Tests
                     new string[0], AssemblyFlags.EditorAssembly);
 
                 var synchronizer = m_Builder
-                    .WithOutputPathForAssemblyPath(assembly.outputPath, assembly.name, assembly.name)
+                    .WithAssembly(assembly)
                     .WithAssetFiles(new[] {"file.hlsl"})
                     .AssignFilesToAssembly(new[] {"file.hlsl"}, assembly)
                     .Build();
@@ -238,7 +238,7 @@ namespace Packages.Rider.Editor.Tests
 
                 var synchronizer = m_Builder
                     .WithAssemblies(new []{riderAssembly})
-                    .WithOutputPathForAssemblyPath(assembly.outputPath, assembly.name, assembly.name)
+                    .WithNameForDefines(assembly.defines, assembly.name, assembly.name)
                     .WithAssetFiles(new[] {"file.hlsl"})
                     .AssignFilesToAssembly(new[] {"file.hlsl"}, assembly)
                     .Build();
@@ -777,7 +777,7 @@ namespace Packages.Rider.Editor.Tests
             [Test]
             public void Containing_PathWithDotCS_IsParsedCorrectly()
             {
-                var assembly = new Assembly("name", "/path/with.cs/assembly.dll", new[] { "file.cs" }, new string[0], new Assembly[0], new string[0], AssemblyFlags.None);
+                var assembly = new Assembly("name", "/path/with.cs/assembly.dll", new[] { "file.cs" }, new string[]{}, new Assembly[0], new string[0], AssemblyFlags.None);
                 var synchronizer = m_Builder
                     .WithAssemblyData(assemblyReferences: new[] { assembly })
                     .Build();

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/SolutionTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/SolutionTests.cs
@@ -81,7 +81,7 @@ namespace Packages.Rider.Editor.Tests
                 Assert.AreNotEqual(solutionText, m_Builder.ReadFile(synchronizer.SolutionFile()), "Should rewrite solution text");
             }
 
-            [TestCase("dll")]
+            [TestCase("asmref")]
             [TestCase("asmdef")]
             public void AfterSync_WillResync_WhenReimportWithSpecialFileExtensions(string reimportedFile)
             {

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/SynchronizerBuilder.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/SynchronizerBuilder.cs
@@ -69,7 +69,7 @@ namespace Packages.Rider.Editor.Tests
 
         public SynchronizerBuilder WithProjectGuid(string projectGuid, Assembly assembly)
         {
-            m_GUIDGenerator.Setup(x => x.ProjectGuid(Path.GetFileName(ProjectDirectory), assembly.name)).Returns(projectGuid);
+            m_GUIDGenerator.Setup(x => x.ProjectGuid(Path.GetFileName(ProjectDirectory) + assembly.name)).Returns(projectGuid);
             return this;
         }
 
@@ -79,7 +79,7 @@ namespace Packages.Rider.Editor.Tests
             m_AssemblyProvider.Setup(x => x.GetAssemblies(It.IsAny<Func<string, bool>>())).Returns(m_Assemblies);
             foreach (var assembly in assemblies)
             {
-                m_AssemblyProvider.Setup(x => x.GetProjectName(assembly.outputPath, assembly.name)).Returns(assembly.name);
+                m_AssemblyProvider.Setup(x => x.GetProjectName(assembly.name, assembly.defines)).Returns(assembly.name);
             }
             return this;
         }
@@ -106,7 +106,13 @@ namespace Packages.Rider.Editor.Tests
                 rootNamespace
             );
 
-            return WithAssembly(assembly);
+            var builder = WithAssembly(assembly);
+            foreach (var assemblyReference in assembly.assemblyReferences)
+            {   
+                builder.WithNameForDefines(assemblyReference.defines, assemblyReference.name, assemblyReference.name);
+            }
+
+            return builder;
         }
 
 #if UNITY_2020_2_OR_NEWER
@@ -194,9 +200,9 @@ namespace Packages.Rider.Editor.Tests
             return this;
         }
 
-        public SynchronizerBuilder WithOutputPathForAssemblyPath(string outputPath, string assemblyName, string resAssemblyName)
+        public SynchronizerBuilder WithNameForDefines(string[] defines, string assemblyName, string resAssemblyName)
         {
-            m_AssemblyProvider.Setup(x => x.GetProjectName(outputPath, assemblyName)).Returns(resAssemblyName);
+            m_AssemblyProvider.Setup(x => x.GetProjectName(assemblyName, defines)).Returns(resAssemblyName);
             return this;
         }
     }

--- a/Packages/com.unity.ide.rider.tests/package.json
+++ b/Packages/com.unity.ide.rider.tests/package.json
@@ -3,8 +3,9 @@
   "name": "com.unity.ide.rider.tests",
   "displayName": "JetBrains Rider Editor Tests",
   "description": "Code editor integration for supporting JetBrains Rider as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
-  "version": "3.1.0",
-  "unity": "2019.4",
+  "version": "3.0.10",
+  "unity": "2019.2",
+  "unityRelease": "6f1",
   "dependencies": {
     "com.unity.test-framework": "1.1.1",
     "nuget.moq": "1.0.0"

--- a/Packages/com.unity.ide.rider.tests/package.json
+++ b/Packages/com.unity.ide.rider.tests/package.json
@@ -4,8 +4,8 @@
   "displayName": "JetBrains Rider Editor Tests",
   "description": "Code editor integration for supporting JetBrains Rider as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
   "version": "3.0.9",
-  "unity": "2019.2",
-  "unityRelease": "6f1",
+  "unity": "2019.4",
+  "unityRelease": "0",
   "dependencies": {
     "com.unity.test-framework": "1.1.1",
     "nuget.moq": "1.0.0"

--- a/Packages/com.unity.ide.rider.tests/package.json
+++ b/Packages/com.unity.ide.rider.tests/package.json
@@ -3,7 +3,7 @@
   "name": "com.unity.ide.rider.tests",
   "displayName": "JetBrains Rider Editor Tests",
   "description": "Code editor integration for supporting JetBrains Rider as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "unity": "2019.4",
   "dependencies": {
     "com.unity.test-framework": "1.1.1",

--- a/Packages/com.unity.ide.rider.tests/package.json
+++ b/Packages/com.unity.ide.rider.tests/package.json
@@ -5,7 +5,6 @@
   "description": "Code editor integration for supporting JetBrains Rider as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
   "version": "3.0.9",
   "unity": "2019.4",
-  "unityRelease": "0",
   "dependencies": {
     "com.unity.test-framework": "1.1.1",
     "nuget.moq": "1.0.0"

--- a/Packages/com.unity.ide.rider/CHANGELOG.md
+++ b/Packages/com.unity.ide.rider/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix presentation of the TargetFramework in the csproj
 - Fix: Auto-generated solution doesn't compile when code overrides virtual functions in other assemblies
+- Fix RIDER-72234 Avoid full project generation, when only content of assembly was changed
+- Fix RIDER-71985 Building large Unity projects randomly fails
+- Fix RIDER-72174 Looking for Rider installed by dotUltimate installer
 
 
 ## [3.0.9] - 2021-11-09

--- a/Packages/com.unity.ide.rider/CHANGELOG.md
+++ b/Packages/com.unity.ide.rider/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Code Editor Package for Rider
 
-## [3.1.0] - 2021-12-09
+## [3.0.10] - 2021-12-09
 
 - Fix presentation of the TargetFramework in the csproj
 - Fix: Auto-generated solution doesn't compile when code overrides virtual functions in other assemblies

--- a/Packages/com.unity.ide.rider/CHANGELOG.md
+++ b/Packages/com.unity.ide.rider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Code Editor Package for Rider
 
+## [3.1.0] - 2021-12-09
+
+- Fix presentation of the TargetFramework in the csproj
+- Fix: Auto-generated solution doesn't compile when code overrides virtual functions in other assemblies
+
+
 ## [3.0.9] - 2021-11-09
 
 Fix path for Roslyn analyser supplied with a package

--- a/Packages/com.unity.ide.rider/CHANGELOG.md
+++ b/Packages/com.unity.ide.rider/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ## [3.0.9] - 2021-11-09
 
-Fix path for Roslyn analyser supplied with a package
+- Fix path for Roslyn analyser supplied with a package
+- Minimal requirement for roslyn analyzer scope is Unity 2020.3.6f1 and above 
 
 
 ## [3.0.8] - 2021-11-08

--- a/Packages/com.unity.ide.rider/Rider/Editor/Discovery.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/Discovery.cs
@@ -308,16 +308,24 @@ namespace Packages.Rider.Editor
     private static void CollectPathsFromRegistry(List<string> installPaths, RegistryKey key)
     {
       if (key == null) return;
-      foreach (var subkeyName in key.GetSubKeyNames().Where(a => a.Contains("Rider")))
+      foreach (var subkeyName in key.GetSubKeyNames())
       {
         using (var subkey = key.OpenSubKey(subkeyName))
         {
           var folderObject = subkey?.GetValue("InstallLocation");
           if (folderObject == null) continue;
           var folder = folderObject.ToString();
-          var possiblePath = Path.Combine(folder, @"bin\rider64.exe");
-          if (File.Exists(possiblePath))
-            installPaths.Add(possiblePath);
+          if (folder.Length == 0) continue;
+          var displayName = subkey.GetValue("DisplayName");
+          if (displayName == null) continue;
+          if (!displayName.ToString().Contains("Rider")) continue;
+          try // possible "illegal characters in path"
+          {
+            var possiblePath = Path.Combine(folder, @"bin\rider64.exe"); 
+            if (File.Exists(possiblePath))
+              installPaths.Add(possiblePath);
+          }
+          catch (ArgumentException) { }
         }
       }
     }

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
@@ -62,6 +62,8 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     public string GetProjectName(string name, string[] defines)
     {
+      if (!ProjectGenerationFlag.HasFlag(ProjectGenerationFlag.PlayerAssemblies))
+        return name;
       return !defines.Contains("UNITY_EDITOR") ? name + ".Player" : name;
     }
 

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
@@ -60,9 +60,9 @@ namespace Packages.Rider.Editor.ProjectGeneration
       }
     }
 
-    public string GetProjectName(string assemblyOutputPath, string assemblyName)
+    public string GetProjectName(string name, string[] defines)
     {
-      return assemblyOutputPath.EndsWith("\\Player\\", StringComparison.Ordinal) ? assemblyName + ".Player" : assemblyName;
+      return !defines.Contains("UNITY_EDITOR") ? name + ".Player" : name;
     }
 
     public IEnumerable<string> GetAllAssetPaths()

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/AssemblyNameProvider.cs
@@ -34,22 +34,23 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     public IEnumerable<Assembly> GetAssemblies(Func<string, bool> shouldFileBePartOfSolution)
     {
-      var assemblies = GetAssembliesByType(AssembliesType.Editor, shouldFileBePartOfSolution, @"Temp\Bin\Debug\");
+      var assemblies = GetAssembliesByType(AssembliesType.Editor, shouldFileBePartOfSolution);
 
       if (!ProjectGenerationFlag.HasFlag(ProjectGenerationFlag.PlayerAssemblies))
       {
         return assemblies;
       }
-      var playerAssemblies = GetAssembliesByType(AssembliesType.Player, shouldFileBePartOfSolution, @"Temp\Bin\Debug\Player\");
+      var playerAssemblies = GetAssembliesByType(AssembliesType.Player, shouldFileBePartOfSolution);
       return assemblies.Concat(playerAssemblies);
     }
 
-    private static IEnumerable<Assembly> GetAssembliesByType(AssembliesType type, Func<string, bool> shouldFileBePartOfSolution, string outputPath)
+    private static IEnumerable<Assembly> GetAssembliesByType(AssembliesType type, Func<string, bool> shouldFileBePartOfSolution)
     {
       foreach (var assembly in CompilationPipeline.GetAssemblies(type))
       {
         if (assembly.sourceFiles.Any(shouldFileBePartOfSolution))
         {
+          string outputPath = type == AssembliesType.Editor ? $@"Temp\Bin\Debug\{assembly.name}\" : $@"Temp\Bin\Debug\{assembly.name}\Player\";    
           yield return new Assembly(assembly.name, outputPath, assembly.sourceFiles, assembly.defines,
             assembly.assemblyReferences, assembly.compiledAssemblyReferences, assembly.flags, assembly.compilerOptions
 #if UNITY_2020_2_OR_NEWER

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/GUIDProvider.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/GUIDProvider.cs
@@ -1,9 +1,9 @@
 namespace Packages.Rider.Editor.ProjectGeneration {
   class GUIDProvider : IGUIDGenerator
   {
-    public string ProjectGuid(string projectName, string assemblyName)
+    public string ProjectGuid(string name)
     {
-      return SolutionGuidGenerator.GuidForProject(projectName + assemblyName);
+      return SolutionGuidGenerator.GuidForProject(name);
     }
   }
 }

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/IAssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/IAssemblyNameProvider.cs
@@ -11,7 +11,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
     ProjectGenerationFlag ProjectGenerationFlag { get; }
 
     string GetAssemblyNameFromScriptPath(string path);
-    string GetProjectName(string assemblyOutputPath, string assemblyName);
+    string GetProjectName(string name, string[] defines);
     bool IsInternalizedPackagePath(string path);
     IEnumerable<Assembly> GetAssemblies(Func<string, bool> shouldFileBePartOfSolution);
     IEnumerable<string> GetAllAssetPaths();

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/IGUIDGenerator.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/IGUIDGenerator.cs
@@ -2,6 +2,6 @@ namespace Packages.Rider.Editor.ProjectGeneration
 {
   internal interface IGUIDGenerator
   {
-    string ProjectGuid(string projectName, string assemblyName);
+    string ProjectGuid(string name);
   }
 }

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -72,7 +72,6 @@ namespace Packages.Rider.Editor.ProjectGeneration
     private const string k_ToolsVersion = "4.0";
     private const string k_ProductVersion = "10.0.20506";
     private const string k_BaseDirectory = ".";
-    private const string k_TargetFrameworkVersion = "v4.7.1";
     private const string k_TargetLanguageVersion = "latest";
 
     IAssemblyNameProvider IGenerator.AssemblyNameProvider => m_AssemblyNameProvider;
@@ -434,9 +433,10 @@ namespace Packages.Rider.Editor.ProjectGeneration
         projectBuilder.Append("  <ItemGroup>").Append(Environment.NewLine);
         foreach (var reference in assembly.AssemblyReferences.Where(i => i.sourceFiles.Any(ShouldFileBePartOfSolution)))
         {
-          projectBuilder.Append("    <ProjectReference Include=\"").Append(reference.name).Append(GetProjectExtension()).Append("\">").Append(Environment.NewLine);
-          projectBuilder.Append("      <Project>{").Append(ProjectGuid(reference.name, reference.outputPath)).Append("}</Project>").Append(Environment.NewLine);
-          projectBuilder.Append("      <Name>").Append(reference.name).Append("</Name>").Append(Environment.NewLine);
+          var name = m_AssemblyNameProvider.GetProjectName(reference.name, reference.defines);
+          projectBuilder.Append("    <ProjectReference Include=\"").Append(name).Append(GetProjectExtension()).Append("\">").Append(Environment.NewLine);
+          projectBuilder.Append("      <Project>{").Append(ProjectGuid(name)).Append("}</Project>").Append(Environment.NewLine);
+          projectBuilder.Append("      <Name>").Append(name).Append("</Name>").Append(Environment.NewLine);
           projectBuilder.Append("    </ProjectReference>").Append(Environment.NewLine);
         }
       }
@@ -457,7 +457,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     private string ProjectFile(ProjectPart projectPart)
     {
-      return Path.Combine(ProjectDirectory, $"{m_AssemblyNameProvider.GetProjectName(projectPart.OutputPath, projectPart.Name)}.csproj");
+      return Path.Combine(ProjectDirectory, $"{m_AssemblyNameProvider.GetProjectName(projectPart.Name, projectPart.Defines)}.csproj");
     }
 
     public string SolutionFile()
@@ -475,7 +475,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
       {
         k_ToolsVersion,
         k_ProductVersion,
-        ProjectGuid(assembly.Name, assembly.OutputPath),
+        ProjectGuid(m_AssemblyNameProvider.GetProjectName(assembly.Name, assembly.Defines)),
         InternalEditorUtility.GetEngineAssemblyPath(),
         InternalEditorUtility.GetEditorAssemblyPath(),
         string.Join(";", assembly.Defines.Concat(responseFilesData.SelectMany(x => x.Defines)).Distinct().ToArray()),
@@ -483,7 +483,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
         assembly.Name,
         assembly.OutputPath,
         assembly.RootNamespace,
-        k_TargetFrameworkVersion,
+        assembly.CompilerOptions.ApiCompatibilityLevel,
         GenerateLangVersion(otherResponseFilesData["langversion"], assembly),
         k_BaseDirectory,
         assembly.CompilerOptions.AllowUnsafeCode | responseFilesData.Any(x => x.Unsafe),
@@ -661,7 +661,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
         @"    <OutputType>Library</OutputType>",
         @"    <AppDesignerFolder>Properties</AppDesignerFolder>",
         @"    <AssemblyName>{7}</AssemblyName>",
-        @"    <TargetFrameworkVersion>{10}</TargetFrameworkVersion>",
+        @"    <TargetFramework>{10}</TargetFramework>",
         @"    <FileAlignment>512</FileAlignment>",
         @"    <BaseDirectory>{12}</BaseDirectory>",
         @"  </PropertyGroup>",
@@ -711,7 +711,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
       
       var projectEntries = GetProjectEntries(islands);
       var projectConfigurations = string.Join(Environment.NewLine,
-        islands.Select(i => GetProjectActiveConfigurations(ProjectGuid(i.Name, i.OutputPath))).ToArray());
+        islands.Select(i => GetProjectActiveConfigurations(ProjectGuid(m_AssemblyNameProvider.GetProjectName(i.Name, i.Defines)))).ToArray());
       return string.Format(GetSolutionText(), fileversion, vsversion, projectEntries, projectConfigurations);
     }
 
@@ -831,7 +831,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
         SolutionGuidGenerator.GuidForSolution(),
         i.Name,
         Path.GetFileName(ProjectFile(i)),
-        ProjectGuid(i.Name, i.OutputPath)
+        ProjectGuid(m_AssemblyNameProvider.GetProjectName(i.Name, i.Defines))
       ));
 
       return string.Join(Environment.NewLine, projectEntries.ToArray());
@@ -857,11 +857,9 @@ namespace Packages.Rider.Editor.ProjectGeneration
       return ".csproj";
     }
 
-    private string ProjectGuid(string name, string outputPath)
+    private string ProjectGuid(string name)
     {
-      return m_GUIDGenerator.ProjectGuid(
-        m_ProjectName,
-        m_AssemblyNameProvider.GetProjectName(outputPath, name));
+      return m_GUIDGenerator.ProjectGuid(m_ProjectName + name);
     }
   }
 }

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -56,8 +56,6 @@ namespace Packages.Rider.Editor.ProjectGeneration
       @"        {{{0}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU",
       @"        {{{0}}}.Debug|Any CPU.Build.0 = Debug|Any CPU").Replace("    ", "\t");
 
-    private static readonly string[] k_ReimportSyncExtensions = { ".dll", ".asmdef", ".asmref" };
-
     private string[] m_ProjectSupportedExtensions = new string[0];
 
     public string ProjectDirectory { get; }
@@ -125,7 +123,8 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     private static bool ShouldSyncOnReimportedAsset(string asset)
     {
-      return k_ReimportSyncExtensions.Contains(Path.GetExtension(asset)) || Path.GetFileName(asset) == "csc.rsp";
+      var extension = Path.GetExtension(asset);
+      return extension == ".asmdef" || extension == ".asmref" || Path.GetFileName(asset) == "csc.rsp";
     }
 
     public void Sync()

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -2,7 +2,7 @@
   "name": "com.unity.ide.rider",
   "displayName": "JetBrains Rider Editor",
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
-  "version": "3.1.0",
+  "version": "3.0.10",
   "unity": "2019.2",
   "unityRelease": "6f1",
   "dependencies": {

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -3,11 +3,12 @@
   "displayName": "JetBrains Rider Editor",
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
   "version": "3.1.0",
-  "unity": "2019.4",
+  "unity": "2019.2",
+  "unityRelease": "6f1",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },
   "relatedPackages": {
-    "com.unity.ide.rider.tests": "3.1.0"
+    "com.unity.ide.rider.tests": "3.0.10"
   }
 }

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -4,7 +4,7 @@
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
   "version": "3.0.9",
   "unity": "2019.4",
-  "unityRelease": "0",
+  "unityRelease": "0a1",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -4,7 +4,6 @@
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
   "version": "3.0.9",
   "unity": "2019.4",
-  "unityRelease": "0a1",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -2,12 +2,12 @@
   "name": "com.unity.ide.rider",
   "displayName": "JetBrains Rider Editor",
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "unity": "2019.4",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },
   "relatedPackages": {
-    "com.unity.ide.rider.tests": "3.0.9"
+    "com.unity.ide.rider.tests": "3.1.0"
   }
 }

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -4,6 +4,7 @@
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
   "version": "3.0.9",
   "unity": "2019.4",
+  "unityRelease": "0a1",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -3,8 +3,8 @@
   "displayName": "JetBrains Rider Editor",
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
   "version": "3.0.9",
-  "unity": "2019.2",
-  "unityRelease": "6f1",
+  "unity": "2019.4",
+  "unityRelease": "0",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },


### PR DESCRIPTION
- Fix presentation of the TargetFramework in the csproj
- Fix: Auto-generated solution doesn't compile when code overrides virtual functions in other assemblies
- Fix RIDER-72234 Avoid full project generation, when only content of assembly was changed
- Fix RIDER-71985 Building large Unity projects randomly fails