### PR TITLE
3.0.15

### DIFF
--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -82,8 +82,8 @@ namespace Packages.Rider.Editor.Tests
 
             foreach (Assembly editorAssembly in editorAssemblies)
             {
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEngine.dll")));
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEditor.dll")));
+                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEngine.dll")), $"UnityEngine.dll not found among {editorAssembly.allReferences.Length} references");
+                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEditor.dll")), $"UnityEditor.dll not found among {editorAssembly.allReferences.Length} references");
             }
         }
 

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -82,8 +82,8 @@ namespace Packages.Rider.Editor.Tests
 
             foreach (Assembly editorAssembly in editorAssemblies)
             {
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEngine.dll")), $"UnityEngine.dll not found among {editorAssembly.allReferences.Length} references");
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEditor.dll")), $"UnityEditor.dll not found among {editorAssembly.allReferences.Length} references");
+                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEngine.dll")), $"Assembly \"{editorAssembly.name}\" doesn't have reference to UnityEngine.dll among {editorAssembly.allReferences.Length} references");
+                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEditor.dll")), $"Assembly \"{editorAssembly.name}\" doesn't have reference to UnityEngine.dll among {editorAssembly.allReferences.Length} references");
             }
         }
 

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/AssemblyNameProviderTests.cs
@@ -76,18 +76,6 @@ namespace Packages.Rider.Editor.Tests
 #endif
 
         [Test]
-        public void AllEditorAssemblies_HaveAReferenceToUnityEditorAndUnityEngine()
-        {
-            var editorAssemblies = CompilationPipeline.GetAssemblies(AssembliesType.Editor);
-
-            foreach (Assembly editorAssembly in editorAssemblies)
-            {
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEngine.dll")), $"Assembly \"{editorAssembly.name}\" doesn't have reference to UnityEngine.dll among {editorAssembly.allReferences.Length} references");
-                Assert.IsTrue(editorAssembly.allReferences.Any(reference => reference.EndsWith("UnityEditor.dll")), $"Assembly \"{editorAssembly.name}\" doesn't have reference to UnityEngine.dll among {editorAssembly.allReferences.Length} references");
-            }
-        }
-
-        [Test]
         public void PlayerAssemblies_AreNotCollected_BeforeToggling()
         {
             var playerAssemblies = CompilationPipeline.GetAssemblies(AssembliesType.Player);

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
@@ -230,7 +230,7 @@ namespace Packages.Rider.Editor.Tests
             [Test] // RIDER-60508 Don't have support for Shaderlab
             public void ShaderWithoutCompileScript_WithReference_WillGetAdded()
             {
-                var assembly = new Assembly("name", "Temp/Bin/Debug", new string[0], new string[0], new Assembly[0],
+                var assembly = new Assembly("name", string.Empty, Array.Empty<string>(), new []{"UNITY_EDITOR"}, new Assembly[0],
                     new string[0], AssemblyFlags.EditorAssembly);
                 var riderAssembly = new Assembly("Unity.Rider.Editor", "Temp/Bin/Debug", new string[0], new string[0],
                     new Assembly[0],

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/SolutionTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/SolutionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEditor.Compilation;
 
@@ -15,7 +16,8 @@ namespace Packages.Rider.Editor.Tests
 
                 synchronizer.Sync();
 
-                Assert.False(m_Builder.ReadFile(synchronizer.SolutionFile()).Contains("Project(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\")"), "Should not create project entry with no assemblies.");
+                var text = m_Builder.ReadFile(synchronizer.SolutionFile());
+                Assert.AreEqual(1, Regex.Matches(text, "Project\\(\"{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}\"\\)").Count);
             }
 
             [Test]

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -211,8 +211,8 @@ namespace Packages.Rider.Editor.ProjectGeneration
           assembly = new Assembly(allAssetProjectPart.Key, riderAssembly.outputPath, new string[0], new string[0],
             new Assembly[0],
             riderAssembly.compiledAssemblyReferences.Where(a =>
-              a.EndsWith("UnityEditor.dll") || a.EndsWith("UnityEngine.dll") ||
-              a.EndsWith("UnityEngine.CoreModule.dll")).ToArray(), riderAssembly.flags);
+              a.EndsWith("UnityEditor.dll", StringComparison.Ordinal) || a.EndsWith("UnityEngine.dll", StringComparison.Ordinal) ||
+              a.EndsWith("UnityEngine.CoreModule.dll", StringComparison.Ordinal)).ToArray(), riderAssembly.flags);
         return new ProjectPart(allAssetProjectPart.Key, assembly, allAssetProjectPart.Value);
       }));
 
@@ -761,7 +761,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
                 return new KeyValuePair<string, string>(warnaserror, b.Substring(warnaserror.Length + 1));
               }
               const string nullable = "nullable";
-              if (b.Substring(1).StartsWith(nullable))
+              if (b.Substring(1).StartsWith(nullable, StringComparison.Ordinal))
               {
                 var res = b.Substring(nullable.Length + 1);
                 if (string.IsNullOrWhiteSpace(res) || res.Equals("+"))

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -829,7 +829,14 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     public static string GenerateNoWarn(List<string> codes)
     {
-#if UNITY_2020_1_OR_NEWER
+#if UNITY_2020_1 // RIDER-77206 Unity 2020.1.3 'PlayerSettings' does not contain a definition for 'suppressCommonWarnings'
+      var type = typeof(PlayerSettings);
+      var propertyInfo = type.GetProperty("suppressCommonWarnings");
+      if (propertyInfo != null && propertyInfo.GetValue(null) is bool)
+      {
+        codes.AddRange(new[] {"0169", "0649"});  
+      }
+#elif UNITY_2020_2_OR_NEWER
       if (PlayerSettings.suppressCommonWarnings)
         codes.AddRange(new[] {"0169", "0649"});
 #endif

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -201,7 +201,8 @@ namespace Packages.Rider.Editor.ProjectGeneration
         projectParts.Add(new ProjectPart(assembly.name, assembly, additionalAssetsForProject));
       }
 
-      var riderAssembly = m_AssemblyNameProvider.GetAssemblies(_ => true).FirstOrDefault(a=>a.name == "Unity.Rider.Editor");
+      var executingAssemblyName = typeof(ProjectGeneration).Assembly.GetName().Name;
+      var riderAssembly = m_AssemblyNameProvider.GetAssemblies(_ => true).FirstOrDefault(a=>a.name == executingAssemblyName);
       var projectPartsWithoutAssembly = allAssetProjectParts.Where(a => !assemblyNames.Contains(a.Key));
       projectParts.AddRange(projectPartsWithoutAssembly.Select(allAssetProjectPart =>
       {

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -205,12 +205,12 @@ namespace Packages.Rider.Editor.ProjectGeneration
       var riderAssembly = m_AssemblyNameProvider.GetAssemblies(_ => true).FirstOrDefault(a=>a.name == executingAssemblyName);
       var projectPartsWithoutAssembly = allAssetProjectParts.Where(a => !assemblyNames.Contains(a.Key));
       projectParts.AddRange(projectPartsWithoutAssembly.Select(allAssetProjectPart => 
-        AddProjectPart(allAssetProjectPart.Key, riderAssembly, allAssetProjectPart.Value)));
+        AddProjectPart(allAssetProjectPart.Key, riderAssembly, allAssetProjectPart.Value, Array.Empty<string>())));
 
       if (!projectParts.Any()) // just an empty project, when there are no files at all
       {
         var assetProjectPart = $"     <Folder Include=\"Assets\"/>{Environment.NewLine}";
-        projectParts.Add(AddProjectPart("Assembly-CSharp", riderAssembly, assetProjectPart));
+        projectParts.Add(AddProjectPart("Assembly-CSharp", riderAssembly, assetProjectPart, new []{"UNITY_EDITOR"}));
       }
 
       SyncSolution(projectParts.ToArray(), types);
@@ -221,13 +221,13 @@ namespace Packages.Rider.Editor.ProjectGeneration
       }
     }
 
-    private static ProjectPart AddProjectPart(string assemblyName, Assembly riderAssembly, string assetProjectPart)
+    private static ProjectPart AddProjectPart(string assemblyName, Assembly riderAssembly, string assetProjectPart, string[] defines)
     {
       Assembly assembly = null;
       if (riderAssembly != null)
         // We want to add those references, so that Rider would detect Unity path and version and provide rich features for shader files
         assembly = new Assembly(assemblyName, riderAssembly.outputPath, Array.Empty<string>(),
-          Array.Empty<string>(),
+          defines,
           Array.Empty<Assembly>(),
           riderAssembly.compiledAssemblyReferences.Where(a =>
             a.EndsWith("UnityEditor.dll", StringComparison.Ordinal) || a.EndsWith("UnityEngine.dll", StringComparison.Ordinal) ||

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -832,7 +832,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
 #if UNITY_2020_1 // RIDER-77206 Unity 2020.1.3 'PlayerSettings' does not contain a definition for 'suppressCommonWarnings'
       var type = typeof(PlayerSettings);
       var propertyInfo = type.GetProperty("suppressCommonWarnings");
-      if (propertyInfo != null && propertyInfo.GetValue(null) is bool)
+      if (propertyInfo != null && propertyInfo.GetValue(null) is bool && (bool)propertyInfo.GetValue(null))
       {
         codes.AddRange(new[] {"0169", "0649"});  
       }

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -205,12 +205,12 @@ namespace Packages.Rider.Editor.ProjectGeneration
       var riderAssembly = m_AssemblyNameProvider.GetAssemblies(_ => true).FirstOrDefault(a=>a.name == executingAssemblyName);
       var projectPartsWithoutAssembly = allAssetProjectParts.Where(a => !assemblyNames.Contains(a.Key));
       projectParts.AddRange(projectPartsWithoutAssembly.Select(allAssetProjectPart => 
-        AddProjectPart(allAssetProjectPart.Key, riderAssembly, allAssetProjectPart.Value, Array.Empty<string>())));
+        AddProjectPart(allAssetProjectPart.Key, riderAssembly, allAssetProjectPart.Value)));
 
       if (!projectParts.Any()) // just an empty project, when there are no files at all
       {
         var assetProjectPart = $"     <Folder Include=\"Assets\"/>{Environment.NewLine}";
-        projectParts.Add(AddProjectPart("Assembly-CSharp", riderAssembly, assetProjectPart, new []{"UNITY_EDITOR"}));
+        projectParts.Add(AddProjectPart("Assembly-CSharp", riderAssembly, assetProjectPart));
       }
 
       SyncSolution(projectParts.ToArray(), types);
@@ -221,13 +221,13 @@ namespace Packages.Rider.Editor.ProjectGeneration
       }
     }
 
-    private static ProjectPart AddProjectPart(string assemblyName, Assembly riderAssembly, string assetProjectPart, string[] defines)
+    private static ProjectPart AddProjectPart(string assemblyName, Assembly riderAssembly, string assetProjectPart)
     {
       Assembly assembly = null;
       if (riderAssembly != null)
         // We want to add those references, so that Rider would detect Unity path and version and provide rich features for shader files
         assembly = new Assembly(assemblyName, riderAssembly.outputPath, Array.Empty<string>(),
-          defines,
+          new []{"UNITY_EDITOR"},
           Array.Empty<Assembly>(),
           riderAssembly.compiledAssemblyReferences.Where(a =>
             a.EndsWith("UnityEditor.dll", StringComparison.Ordinal) || a.EndsWith("UnityEngine.dll", StringComparison.Ordinal) ||

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -134,8 +134,6 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
     public void Sync()
     {
-      m_AssemblyNameProvider.ResetPackageInfoCache();
-      m_AssemblyNameProvider.ResetAssembliesCache();
       SetupSupportedExtensions();
       var types = GetAssetPostprocessorTypes();
       isRiderProjectGeneration = true;
@@ -147,6 +145,8 @@ namespace Packages.Rider.Editor.ProjectGeneration
       }
 
       OnGeneratedCSProjectFiles(types);
+      m_AssemblyNameProvider.ResetPackageInfoCache();
+      m_AssemblyNameProvider.ResetAssembliesCache();
     }
 
     public bool HasSolutionBeenGenerated()


### PR DESCRIPTION
Cleanup cache after project generation to reduce memory consumption
Performance optimization
RIDER-76126 Rider package should generate an empty csproj for empty Unity project
RIDER-77206 Unity 2020.1.3 'PlayerSettings' does not contain a definition for 'suppressCommonWarnings