### PR TITLE
fix additionalfile-related tests on Windows (use the same path normalization for expected values as the ProjectGeneration uses)

### DIFF
--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
@@ -511,7 +511,7 @@ namespace Packages.Rider.Editor.Tests
                 synchronizer.Sync();
 
                 var csprojFileContents = m_Builder.ReadProjectFile(m_Builder.Assembly);
-                StringAssert.Contains($"<AdditionalFiles Include=\"Filename.AnalyzerName.additionalfile\" />", csprojFileContents);
+                Assert.That(csprojFileContents, Does.Match(@"<AdditionalFiles Include="".*Filename\.AnalyzerName\.additionalfile"" />"));
             }
 
             [Test]

--- a/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.rider.tests/Tests/Editor/CSProjectTests.cs
@@ -511,7 +511,8 @@ namespace Packages.Rider.Editor.Tests
                 synchronizer.Sync();
 
                 var csprojFileContents = m_Builder.ReadProjectFile(m_Builder.Assembly);
-                Assert.That(csprojFileContents, Does.Match(@"<AdditionalFiles Include="".*Filename\.AnalyzerName\.additionalfile"" />"));
+                var normalisedPath = FileSystemUtil.GetNormalizedFullPath("Filename.AnalyzerName.additionalfile");
+                StringAssert.Contains($"<AdditionalFiles Include=\"{normalisedPath}\" />", csprojFileContents);
             }
 
             [Test]
@@ -575,7 +576,7 @@ namespace Packages.Rider.Editor.Tests
             {
                 var combined = string.Join(";", paths);
                 const string additionalFileTemplate = @"    <AdditionalFiles Include=""{0}"" />";
-                var expectedOutput = paths.Select(x => string.Format(additionalFileTemplate, x)).ToArray();
+                var expectedOutput = paths.Select(x => string.Format(additionalFileTemplate, FileSystemUtil.GetNormalizedFullPath(x))).ToArray();
 
                 CheckOtherArgument(new[] { $"-additionalfile:{combined}" }, expectedOutput);
                 CheckOtherArgument(new[] { $"/additionalfile:{combined}" }, expectedOutput);

--- a/Packages/com.unity.ide.rider.tests/package.json
+++ b/Packages/com.unity.ide.rider.tests/package.json
@@ -3,7 +3,7 @@
   "name": "com.unity.ide.rider.tests",
   "displayName": "JetBrains Rider Editor Tests",
   "description": "Code editor integration for supporting JetBrains Rider as code editor for unity. Adds support for generating csproj files for intellisense purposes, auto discovery of installations, etc.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "unity": "6000.5",
   "dependencies": {
     "com.unity.test-framework": "1.1.1",

--- a/Packages/com.unity.ide.rider/CHANGELOG.md
+++ b/Packages/com.unity.ide.rider/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Code Editor Package for Rider
+## [3.1.1] - 2026-03-13
+
+- Normalise paths for additional files for roslyn, fixes RIDER-136169 Roslyn process gets stuck
+
 ## [3.1.0] - 2026-01-02
 
 - Switch to the SDK style project format.

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -613,7 +613,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
 
       foreach (var reference in binaryReferences)
       {
-        var escapedFullPath = GetNormalisedAssemblyPath(reference);
+        var escapedFullPath = GetNormalisedPath(reference);
         var assemblyName = GetAssemblyNameFromPath(reference);
         projectBuilder
           .Append("    <Reference Include=\"").Append(assemblyName).AppendLine("\">")
@@ -784,7 +784,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
       return configFile;
     }
 
-    private static string[] GetRoslynAdditionalFiles(ProjectPart assembly, ILookup<string, string> otherResponseFilesData)
+    private string[] GetRoslynAdditionalFiles(ProjectPart assembly, ILookup<string, string> otherResponseFilesData)
     {
       var additionalFilePathsFromCompilationPipeline = Array.Empty<string>();
 #if UNITY_2021_3 // https://github.com/JetBrains/resharper-unity/issues/2401
@@ -800,6 +800,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
       return otherResponseFilesData["additionalfile"]
         .SelectMany(x=>x.Split(';'))
         .Concat(additionalFilePathsFromCompilationPipeline)
+        .Select(GetNormalisedPath)
         .Distinct().ToArray();
     }
 
@@ -813,7 +814,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
 #else
         .Concat(assembly.CompilerOptions.RoslynAnalyzerDllPaths)
 #endif
-        .Select(GetNormalisedAssemblyPath)
+        .Select(GetNormalisedPath)
         .Distinct()
         .ToArray();
 #else
@@ -833,7 +834,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
         paths.Add(assembly.CompilerOptions.RoslynAnalyzerRulesetPath);
 #endif
 
-      return paths.Select(GetNormalisedAssemblyPath);
+      return paths.Select(GetNormalisedPath);
     }
 
     private static void AppendWarningAsError(StringBuilder stringBuilder,
@@ -989,7 +990,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
       return guid;
     }
 
-    private string GetNormalisedAssemblyPath(string path)
+    private string GetNormalisedPath(string path)
     {
       if (!m_NormalisedPaths.TryGetValue(path, out var normalisedPath))
       {

--- a/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security;
 using System.Text;
 using Packages.Rider.Editor.Util;
 using UnityEditor;
@@ -994,8 +993,7 @@ namespace Packages.Rider.Editor.ProjectGeneration
     {
       if (!m_NormalisedPaths.TryGetValue(path, out var normalisedPath))
       {
-        normalisedPath = Path.IsPathRooted(path) ? path : Path.GetFullPath(path);
-        normalisedPath = SecurityElement.Escape(normalisedPath).NormalizePath();
+        normalisedPath = FileSystemUtil.GetNormalizedFullPath(path);
         m_NormalisedPaths.Add(path, normalisedPath);
       }
 

--- a/Packages/com.unity.ide.rider/Rider/Editor/Util/FileSystemUtil.cs
+++ b/Packages/com.unity.ide.rider/Rider/Editor/Util/FileSystemUtil.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Security;
 using System.Text;
 using JetBrains.Annotations;
 using UnityEngine;
@@ -55,6 +56,13 @@ namespace Packages.Rider.Editor.Util
       }
 
       return path.Substring(indexOfSlash, indexOfDot - indexOfSlash);
+    }
+
+    public static string GetNormalizedFullPath(string path)
+    {
+      var normalisedPath = Path.IsPathRooted(path) ? path : Path.GetFullPath(path);
+      normalisedPath = SecurityElement.Escape(normalisedPath).NormalizePath();
+      return normalisedPath;
     }
     
     public static bool EditorPathExists(string editorPath)

--- a/Packages/com.unity.ide.rider/package.json
+++ b/Packages/com.unity.ide.rider/package.json
@@ -2,12 +2,12 @@
   "name": "com.unity.ide.rider",
   "displayName": "JetBrains Rider Editor",
   "description": "The JetBrains Rider Editor package provides an integration for using the JetBrains Rider IDE as a code editor for Unity. It adds support for generating .csproj files for code completion and auto-discovery of installations.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "unity": "6000.5",
   "dependencies": {
     "com.unity.ext.nunit": "1.0.6"
   },
   "relatedPackages": {
-    "com.unity.ide.rider.tests": "3.1.0"
+    "com.unity.ide.rider.tests": "3.1.1"
   }
 }


### PR DESCRIPTION
this reverts the test change from bcc3000 back to StringAssert.Contains, this time using normalized path instead of regexp matching